### PR TITLE
Correct namespace in privacy provider.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -22,7 +22,7 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-namespace availability_grouping\privacy;
+namespace availability_quizquestion\privacy;
 
 defined('MOODLE_INTERNAL') || die();
 


### PR DESCRIPTION
Throws

`Fatal error: Cannot declare class availability_grouping\privacy\provider, because the name is already in use in …/moodle/availability/condition/quizquestion/classes/privacy/provider.php on line 32
`

otherwise in a full Behat run.

Thanks!