### PR TITLE
Make the plugin tests work for Moodle 4.1 onwards as well.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:12
+        image: postgres:13
         env:
           POSTGRES_USER: 'postgres'
           POSTGRES_HOST_AUTH_METHOD: 'trust'
@@ -17,7 +17,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 3
 
       mariadb:
-        image: mariadb:10
+        image: mariadb:10.6
         env:
           MYSQL_USER: 'root'
           MYSQL_ALLOW_EMPTY_PASSWORD: "true"
@@ -31,8 +31,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - php: '8.0'
+          - php: '8.1'
             moodle-branch: 'master'
+            database: 'mariadb'
+          - php: '8.1'
+            moodle-branch: 'MOODLE_402_STABLE'
+            database: 'pgsql'
+          - php: '8.0'
+            moodle-branch: 'MOODLE_401_STABLE'
             database: 'mariadb'
           - php: '7.3'
             moodle-branch: 'MOODLE_400_STABLE'
@@ -40,7 +46,7 @@ jobs:
 
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: plugin
 

--- a/classes/condition.php
+++ b/classes/condition.php
@@ -147,7 +147,11 @@ class condition extends \core_availability\condition {
 
         if (count($attempts) > 0) {
 
-            $attemptobj = \quiz_attempt::create(end($attempts)->id);
+            if (class_exists('\\mod_quiz\\quiz_attempt')) {
+                $attemptobj = \mod_quiz\quiz_attempt::create(end($attempts)->id);
+            } else {
+                $attemptobj = \quiz_attempt::create(end($attempts)->id);
+            }
 
             foreach ($attemptobj->get_slots() as $slot) {
                 $qa = $attemptobj->get_question_attempt($slot);

--- a/classes/question_list_fetcher.php
+++ b/classes/question_list_fetcher.php
@@ -21,8 +21,10 @@ use mod_quiz\question\bank\qbank_helper;
 defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
-require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
 require_once($CFG->libdir . '/questionlib.php');
+if ($CFG->release < 4.2) {
+    require_once($CFG->dirroot . '/mod/quiz/attemptlib.php');
+}
 
 /**
  * Helper class to get the list of question options to show on the settings form.

--- a/tests/behat/availability_quizquestion.feature
+++ b/tests/behat/availability_quizquestion.feature
@@ -32,7 +32,8 @@ Feature: Restriction by single quiz question
       | Writing  | 1    | 1       |
 
   @javascript
-  Scenario: Test basic use
+  Scenario: Test basic use Moodle ≥ 4.1
+    Given the site is running Moodle version 4.1 or higher
     # Set up as teacher.
     Given I am on the "C1" "Course" page logged in as "teacher"
     And I turn editing mode on
@@ -45,7 +46,41 @@ Feature: Restriction by single quiz question
     And I set the field "Quiz question" to "Diagnostic quiz"
     And I set the field "Which question in the selected quiz" to "Q1) Reading"
     And I set the field "Required state" to "Incorrect"
-    And I click on "Displayed greyed-out if user does not meet this condition" "link"
+    And I click on "Displayed if student doesn't meet this condition • Click to hide" "link"
+    And I click on "Save and return to course" "button"
+
+    # Try it as student - no access yet.
+    And I log out
+    And I am on the "C1" "Course" page logged in as "student"
+    Then I should not see "Help with reading"
+
+    # Now attempt the quiz.
+    And I follow "Diagnostic quiz"
+    And I press "Attempt quiz"
+    And I click on "False" "radio" in the "I am good at reading?" "question"
+    And I click on "False" "radio" in the "I am good at writing?" "question"
+    And I follow "Finish attempt ..."
+    And I press "Submit all and finish"
+    And I click on "Submit all and finish" "button" in the "Submit all your answers and finish?" "dialogue"
+    And I am on the "C1" "Course" page
+    And I follow "Help with reading"
+    And I should see "Open your eyes!"
+
+  Scenario: Test basic use Moodle ≤ 4.0
+    Given the site is running Moodle version 4.0 or lower
+    # Set up as teacher.
+    Given I am on the "C1" "Course" page logged in as "teacher"
+    And I turn editing mode on
+    When I add a "Page" to section "1"
+    And I set the following fields to these values:
+      | Name         | Help with reading |
+      | Page content | Open your eyes!   |
+    And I click on "Add restriction..." "button"
+    And I click on "Quiz question" "button" in the "Add restriction..." "dialogue"
+    And I set the field "Quiz question" to "Diagnostic quiz"
+    And I set the field "Which question in the selected quiz" to "Q1) Reading"
+    And I set the field "Required state" to "Incorrect"
+    And I click on "Displayed if student doesn't meet this condition • Click to hide" "link"
     And I click on "Save and return to course" "button"
 
     # Try it as student - no access yet.

--- a/tests/condition_test.php
+++ b/tests/condition_test.php
@@ -122,7 +122,12 @@ class condition_test extends \advanced_testcase {
                 ['category' => $category->id]);
         $question = \question_bank::load_question_data($question->id); // Reload to get questionbankentryid.
         quiz_add_quiz_question($question->id, $quiz);
-        quiz_update_sumgrades($quiz);
+        if (class_exists('\\mod_quiz\\grade_calculator')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+            $quizobj->get_grade_calculator()->recompute_quiz_sumgrades();
+        } else {
+            quiz_update_sumgrades($quiz);
+        }
 
         // Do test (user has not attempted the quiz yet).
         $cond = new condition((object) [
@@ -143,13 +148,21 @@ class condition_test extends \advanced_testcase {
 
         // User attempts the quiz and get the question right.
         $timenow = time();
-        $quizobj = \quiz::create($quiz->id, $user->id);
+        if (class_exists('\\mod_quiz\\quiz_settings')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+        } else {
+            $quizobj = \quiz::create($quiz->id, $user->id);
+        }
         $quba = \question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
         $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
         $attempt = quiz_create_attempt($quizobj, 1, null, $timenow, false, $user->id);
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
-        $attemptobj = \quiz_attempt::create($attempt->id);
+        if (class_exists('\\mod_quiz\\quiz_attempt')) {
+            $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        } else {
+            $attemptobj = \quiz_attempt::create($attempt->id);
+        }
         $tosubmit = [1 => ['answer' => '3.14']];
         $attemptobj->process_submitted_actions(time(), false, $tosubmit);
         $attemptobj->process_finish(time(), false);
@@ -163,13 +176,21 @@ class condition_test extends \advanced_testcase {
 
         // User attempts the quiz and get the question wrong.
         $timenow = time();
-        $quizobj = \quiz::create($quiz->id, $user->id);
+        if (class_exists('\\mod_quiz\\quiz_settings')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+        } else {
+            $quizobj = \quiz::create($quiz->id, $user->id);
+        }
         $quba = \question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
         $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
         $attempt = quiz_create_attempt($quizobj, 2, null, $timenow, false, $user->id);
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
-        $attemptobj = \quiz_attempt::create($attempt->id);
+        if (class_exists('\\mod_quiz\\quiz_attempt')) {
+            $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        } else {
+            $attemptobj = \quiz_attempt::create($attempt->id);
+        }
         $tosubmit = [1 => ['answer' => '42']];
         $attemptobj->process_submitted_actions(time(), false, $tosubmit);
         $attemptobj->process_finish(time(), false);
@@ -205,7 +226,12 @@ class condition_test extends \advanced_testcase {
                 ['category' => $category->id]);
         $question = \question_bank::load_question_data($question->id); // Reload to get questionbankentryid.
         quiz_add_quiz_question($question->id, $quiz);
-        quiz_update_sumgrades($quiz);
+        if (class_exists('\\mod_quiz\\grade_calculator')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+            $quizobj->get_grade_calculator()->recompute_quiz_sumgrades();
+        } else {
+            quiz_update_sumgrades($quiz);
+        }
 
         // Do test (user has not attempted the quiz yet).
         $legacycond = new condition((object) [
@@ -226,13 +252,21 @@ class condition_test extends \advanced_testcase {
 
         // User attempts the quiz and get the question right.
         $timenow = time();
-        $quizobj = \quiz::create($quiz->id, $user->id);
+        if (class_exists('\\mod_quiz\\quiz_settings')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+        } else {
+            $quizobj = \quiz::create($quiz->id, $user->id);
+        }
         $quba = \question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
         $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
         $attempt = quiz_create_attempt($quizobj, 1, null, $timenow, false, $user->id);
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
-        $attemptobj = \quiz_attempt::create($attempt->id);
+        if (class_exists('\\mod_quiz\\quiz_attempt')) {
+            $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        } else {
+            $attemptobj = \quiz_attempt::create($attempt->id);
+        }
         $tosubmit = [1 => ['answer' => '3.14']];
         $attemptobj->process_submitted_actions(time(), false, $tosubmit);
         $attemptobj->process_finish(time(), false);
@@ -246,13 +280,21 @@ class condition_test extends \advanced_testcase {
 
         // User attempts the quiz and get the question wrong.
         $timenow = time();
-        $quizobj = \quiz::create($quiz->id, $user->id);
+        if (class_exists('\\mod_quiz\\quiz_settings')) {
+            $quizobj = \mod_quiz\quiz_settings::create($quiz->id, $user->id);
+        } else {
+            $quizobj = \quiz::create($quiz->id, $user->id);
+        }
         $quba = \question_engine::make_questions_usage_by_activity('mod_quiz', $quizobj->get_context());
         $quba->set_preferred_behaviour($quizobj->get_quiz()->preferredbehaviour);
         $attempt = quiz_create_attempt($quizobj, 2, null, $timenow, false, $user->id);
         quiz_start_new_attempt($quizobj, $quba, $attempt, 1, $timenow);
         quiz_attempt_save_started($quizobj, $quba, $attempt);
-        $attemptobj = \quiz_attempt::create($attempt->id);
+        if (class_exists('\\mod_quiz\\quiz_attempt')) {
+            $attemptobj = \mod_quiz\quiz_attempt::create($attempt->id);
+        } else {
+            $attemptobj = \quiz_attempt::create($attempt->id);
+        }
         $tosubmit = [1 => ['answer' => '42']];
         $attemptobj->process_submitted_actions(time(), false, $tosubmit);
         $attemptobj->process_finish(time(), false);

--- a/tests/question_list_fetcher_test.php
+++ b/tests/question_list_fetcher_test.php
@@ -15,11 +15,6 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 namespace availability_quizquestion;
-defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
-require_once($CFG->dirroot . '/backup/util/includes/backup_includes.php');
-require_once($CFG->dirroot . '/backup/util/includes/restore_includes.php');
 
 /**
  * Tests for the code that gets a list of questions in a quiz.


### PR DESCRIPTION
I'm inquiring a case at my place where the setting of a condition based on a quiz question wouldn't work
(Maybe if the conditioning test itself is already covered by a conditional visibility? Is that a possibility?).

Thought it was a good thing to have the PHPUnit and Behat tests pass.
Note I did apply to make them for 4.0, 4.1 and 4.2 in a single version: differences in those occur with dialog texts rephrasing (having to be dealt with in Behat tests) and autoloaded classes/deprecated methods.

Feel free to merge.

Best,
Luca